### PR TITLE
Change block wording

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -60,7 +60,7 @@
   var descriptor = {
     blocks: [
       ['R', 'latest tweet from @%s', 'latestUserTweet', 'scratch'],
-      ['R', 'get the most %m.sort tweet containing %s', 'getTopTweet', 'popular', '#scratch'],
+      ['R', 'most %m.sort tweet containing %s', 'getTopTweet', 'popular', '#scratch'],
     ],
     menus: {
       sort: ["popular", "recent"]


### PR DESCRIPTION
Does it sound better to drop the 'get the' off the top tweet block?

![toptweet](https://cloud.githubusercontent.com/assets/1169507/8973629/23b638b4-3635-11e5-8400-9140459c52fd.png)
